### PR TITLE
fix rendering issue #8

### DIFF
--- a/content/AFSC-BSAI-AtkaMackerel.qmd
+++ b/content/AFSC-BSAI-AtkaMackerel.qmd
@@ -15,18 +15,16 @@ editor_options:
 #| label: startup
 #| output: false
 
-packages <- c("dplyr", "tidyr", "ggplot2", "TMB", "remotes")
+packages <- c("dplyr", "tidyr", "ggplot2", "remotes", "here", "TMB")
 # Install packages not yet installed
 installed_packages <- packages %in% rownames(installed.packages())
 if (any(installed_packages == FALSE)) {
   install.packages(packages[!installed_packages], repos = "http://cran.us.r-project.org")
 }
-#remotes::install_github("NOAA-FIMS/FIMS", ref='isNA')
-remotes::install_github("kaskr/TMB_contrib_R/TMBhelper")
 
-library(ggplot2)
-library(tidyr)
-library(dplyr)
+# Load packages
+invisible(lapply(packages, library, character.only = TRUE))
+
 library(FIMS)
 library(TMB)
 library(TMBhelper)

--- a/content/AFSC-GOA-pollock.qmd
+++ b/content/AFSC-GOA-pollock.qmd
@@ -12,24 +12,20 @@ format:
 #| label: startup
 #| output: false
 
-packages <- c("dplyr", "tidyr", "ggplot2", "TMB", "remotes", "reshape2")
+packages <- c("dplyr", "tidyr", "ggplot2", "remotes", "reshape2", "TMB")
 # Install packages not yet installed
 installed_packages <- packages %in% rownames(installed.packages())
 if (any(installed_packages == FALSE)) {
   install.packages(packages[!installed_packages], repos = "http://cran.us.r-project.org")
 }
-#remotes::install_github("NOAA-FIMS/FIMS")
-#remotes::install_github("NOAA-FIMS/FIMS", ref='isNA')
-#remotes::install_github("kaskr/TMB_contrib_R/TMBhelper")
 
-library(ggplot2)
-library(tidyr)
-library(dplyr)
+# Load packages
+invisible(lapply(packages, library, character.only = TRUE))
+
 library(FIMS)
 library(TMB)
 library(TMBhelper)
-## devtools::install_github('afsc-assessments/GOApollock', ref='v0.1.2')
-## library(GOApollock)
+
 theme_set(theme_bw())
 
 

--- a/content/NEFSC-yellowtail.qmd
+++ b/content/NEFSC-yellowtail.qmd
@@ -9,20 +9,21 @@ format:
 
 ```{r}
 #| warning: false
+#| label: package-installation
 # Names of required packages
-packages <- c("dplyr", "tidyr", "ggplot2", "TMB", "remotes")
+packages <- c("dplyr", "tidyr", "ggplot2", "remotes", "TMB")
 
 # Install packages not yet installed
 installed_packages <- packages %in% rownames(installed.packages())
 if (any(installed_packages == FALSE)) {
   install.packages(packages[!installed_packages], repos = "http://cran.us.r-project.org")
 }
-#remotes::install_github("NOAA-FIMS/FIMS")
-remotes::install_github("kaskr/TMB_contrib_R/TMBhelper")
 
 # Load packages
 invisible(lapply(packages, library, character.only = TRUE))
 library(FIMS)
+library(TMB)
+library(TMBhelper)
 
 R_version <- version$version.string
 TMB_version <- packageDescription("TMB")$Version
@@ -64,6 +65,7 @@ The catch weight at age matrix was used as the weight at age for all sources.
 ## Script that sets up and runs the model
 ```{r}
 #| warning: false
+#| label: run-fims
 
 # clear memory
 clear()
@@ -469,6 +471,7 @@ if(saveplots){
 The likelihood components from FIMS and ASAP for the same data are shown in the table below. Note that the ASAP file had to turn on the use likelihood constants option to enable this comparison (this option should not be used when recruitment deviations are estimated).
 
 ```{r}
+#| label: comparison-table
 jnlltab <- data.frame(Component=c("Total","Index","Age Comp", "Rec"),
                       FIMS = c(report$jnll, report$index_nll, report$age_comp_nll, report$rec_nll),
                       ASAP = c(rdat$like$lk.total,
@@ -504,6 +507,7 @@ Please [open an issue](https://github.com/NOAA-FIMS/FIMS/issues/new/choose) if y
 * Missing values, would allow inclusion of the other 3 indices (too many missing years to fill for this example)
 
 ```{r}
+#| label: clear-C++-objects-from-memory
 # Clear C++ objects from memory
 clear()
 ```


### PR DESCRIPTION
This PR addresses the issue https://github.com/NOAA-FIMS/case-studies/issues/8. The following adjustments have been implemented across multiple case studies:

- installed {here} for the Atka Mackerel case study
- Removed redundant installation steps for {FIMS} and {TMBhelper} from individual case studies as they are installed via the GHA workflow
- loaded both {FIMS} and {TMBhelper} in individual case studies