### PR TITLE
Add setup.qmd file to facilitate the management of all required packages in the repository's code

### DIFF
--- a/.github/workflows/render-and-publish.yml
+++ b/.github/workflows/render-and-publish.yml
@@ -18,13 +18,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
 
       - name: Install packages (needed for Rmd)
-        run: Rscript -e 'install.packages(c("rmarkdown", "knitr", "jsonlite","dplyr","tidyr","ggplot2", "TMB", "remotes"))'
-
-      - name: Install TMB helper
-        run: Rscript -e 'remotes::install_github("kaskr/TMB_contrib_R/TMBhelper")'
-
-      - name: Install FIMS
-        run: Rscript -e 'remotes::install_github("NOAA-FIMS/FIMS")'
+        run: Rscript -e 'install.packages(c("rmarkdown", "knitr", "jsonlite"))'
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -35,8 +35,6 @@ website:
         text: Home
       - href: content/case-study-template.qmd
         text: Case study template
-      - href: content/SWFSC-sardine.qmd
-        text: SWFSC sardine case study
       - href: content/rendering.qmd
         text: Rendering
       - href: content/rmarkdown.Rmd
@@ -47,6 +45,8 @@ website:
         text: AFSC GOA pollock case study
       - href: content/AFSC-BSAI-AtkaMackerel.qmd
         text: AFSC BSAI Atka Mackerel case study
+      - href: content/SWFSC-sardine.qmd
+        text: SWFSC sardine case study
       - href: content/acknowledgements.qmd
         text: Acknowledgements
 

--- a/content/AFSC-BSAI-AtkaMackerel.qmd
+++ b/content/AFSC-BSAI-AtkaMackerel.qmd
@@ -7,35 +7,21 @@ editor_options:
   chunk_output_type: console
 ---
 
-
 ## The setup
+
+{{< include setup.qmd >}}
 
 ```{r}
 #| warning: false
 #| label: startup
 #| output: false
 
-packages <- c("dplyr", "tidyr", "ggplot2", "remotes", "here", "TMB")
-# Install packages not yet installed
-installed_packages <- packages %in% rownames(installed.packages())
-if (any(installed_packages == FALSE)) {
-  install.packages(packages[!installed_packages], repos = "http://cran.us.r-project.org")
-}
-
-# Load packages
-invisible(lapply(packages, library, character.only = TRUE))
-
-library(FIMS)
-library(TMB)
-library(TMBhelper)
-## devtools::install_github('afsc-assessments/GOApollock', ref='v0.1.2')
-## library(GOApollock)
 theme_set(theme_bw())
 
 
-R_version <- version$version.string
-TMB_version <- packageDescription("TMB")$Version
-FIMS_commit <- substr(packageDescription("FIMS")$GithubSHA1, 1, 7)
+# R_version <- version$version.string
+# TMB_version <- packageDescription("TMB")$Version
+# FIMS_commit <- substr(packageDescription("FIMS")$GithubSHA1, 1, 7)
 ```
 
 -   R version: `r R_version`\

--- a/content/AFSC-GOA-pollock.qmd
+++ b/content/AFSC-GOA-pollock.qmd
@@ -7,31 +7,19 @@ format:
 
 ## The setup
 
+{{< include setup.qmd >}}
+
 ```{r}
 #| warning: false
 #| label: startup
 #| output: false
 
-packages <- c("dplyr", "tidyr", "ggplot2", "remotes", "reshape2", "TMB")
-# Install packages not yet installed
-installed_packages <- packages %in% rownames(installed.packages())
-if (any(installed_packages == FALSE)) {
-  install.packages(packages[!installed_packages], repos = "http://cran.us.r-project.org")
-}
-
-# Load packages
-invisible(lapply(packages, library, character.only = TRUE))
-
-library(FIMS)
-library(TMB)
-library(TMBhelper)
-
 theme_set(theme_bw())
 
 
-R_version <- version$version.string
-TMB_version <- packageDescription("TMB")$Version
-FIMS_commit <- substr(packageDescription("FIMS")$GithubSHA1, 1, 7)
+# R_version <- version$version.string
+# TMB_version <- packageDescription("TMB")$Version
+# FIMS_commit <- substr(packageDescription("FIMS")$GithubSHA1, 1, 7)
 ```
 
 -   R version: `r R_version`\

--- a/content/NEFSC-yellowtail.qmd
+++ b/content/NEFSC-yellowtail.qmd
@@ -7,27 +7,15 @@ format:
 
 ## The setup
 
+{{< include setup.qmd >}}
+
 ```{r}
 #| warning: false
-#| label: package-installation
-# Names of required packages
-packages <- c("dplyr", "tidyr", "ggplot2", "remotes", "TMB")
+#| label: startup
 
-# Install packages not yet installed
-installed_packages <- packages %in% rownames(installed.packages())
-if (any(installed_packages == FALSE)) {
-  install.packages(packages[!installed_packages], repos = "http://cran.us.r-project.org")
-}
-
-# Load packages
-invisible(lapply(packages, library, character.only = TRUE))
-library(FIMS)
-library(TMB)
-library(TMBhelper)
-
-R_version <- version$version.string
-TMB_version <- packageDescription("TMB")$Version
-FIMS_commit <- substr(packageDescription("FIMS")$GithubSHA1, 1, 7)
+# R_version <- version$version.string
+# TMB_version <- packageDescription("TMB")$Version
+# FIMS_commit <- substr(packageDescription("FIMS")$GithubSHA1, 1, 7)
 ```
 
 -   R version: `r R_version`\

--- a/content/case-study-template.qmd
+++ b/content/case-study-template.qmd
@@ -21,12 +21,15 @@ and start the qmd file with a level header `# `, but if using the default title 
 ## Add a chunk of code describing your setup
 
 Case study files should include:
+
 * R version
 * TMB version
 * FIMS commit
 * Name of your stock
 * Name of your region
 * Name of the analyst
+
+Please ensure that the [`content/setup.qmd`](https://github.com/NOAA-FIMS/case-studies/blob/main/content/setup.qmd) file is updated if the case study requires the installation of additional R packages.
 
 ## Add a bulleted list and script describing simplifications you had to make
 

--- a/content/setup.qmd
+++ b/content/setup.qmd
@@ -1,0 +1,26 @@
+```{r}
+#| warning: false
+#| label: package-installation
+
+# Names of required packages
+packages <- c("dplyr", "tidyr", "ggplot2", "TMB", "reshape2", "here", "remotes")
+
+# Install packages not yet installed
+installed_packages <- packages %in% rownames(installed.packages())
+if (any(installed_packages == FALSE)) {
+  install.packages(packages[!installed_packages], repos = "http://cran.us.r-project.org")
+}
+
+remotes::install_github("kaskr/TMB_contrib_R/TMBhelper")
+remotes::install_github("NOAA-FIMS/FIMS")
+
+# Load packages
+invisible(lapply(packages, library, character.only = TRUE))
+
+library(FIMS)
+library(TMBhelper)
+
+R_version <- version$version.string
+TMB_version <- packageDescription("TMB")$Version
+FIMS_commit <- substr(packageDescription("FIMS")$GithubSHA1, 1, 7)
+```

--- a/index.qmd
+++ b/index.qmd
@@ -5,8 +5,3 @@ page-layout: full
 ---
 
 These case studies demonstrate use of the Fisheries Integrated Modeling System to run a few different cases of stock assessment models. 
-
-```{r, eval = FALSE}
-install.packages(c("dplyr","tidyr","ggplot2","TMB","TMBhelper")
-remotes::install_github("NOAA-FIMS/FIMS")
-```


### PR DESCRIPTION
This PR addresses the issue https://github.com/NOAA-FIMS/case-studies/issues/5. The following modifications have been implemented:

- Added a `content/setup.qmd` file to facilitate the management of all required packages in the repository's code, eliminating the need to update names of packages in multiple files. 
- Revised `content/case-study-template.qmd` to include instructions for installing additional required packages.
- Updated case studies to remove repetitive package installations.
- Updated `render-and-publish.yml` by removing the section for installing {FIMS} and {TMBhelper}.

Passed GHA log can be found [here](https://github.com/Bai-Li-NOAA/case-studies/actions/runs/7922820149/job/21631284479)
