### PR TITLE
Render pages on pull request 

### DIFF
--- a/.github/workflows/render-on-pull-request.yml
+++ b/.github/workflows/render-on-pull-request.yml
@@ -1,0 +1,39 @@
+on:
+  pull_request:
+    branches: main
+
+name: Render on pull request
+
+jobs:
+  build-deploy:
+    runs-on: macos-latest
+    env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2 
+        
+      - name: Set up R (needed for Rmd)
+        uses: r-lib/actions/setup-r@v2
+
+      - name: Install packages (needed for Rmd)
+        run: Rscript -e 'install.packages(c("rmarkdown", "knitr", "jsonlite"))'
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          # To install LaTeX to build PDF book 
+          tinytex: true 
+          # uncomment below and fill to pin a version
+          # version: 0.9.600
+      
+      # add software dependencies here
+
+      - name: Render Quarto Project 
+        uses: quarto-dev/quarto-actions/render@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # this secret is always available for github actions
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This is a [website](https://noaa-fims.github.io/case-studies/) (`type: website`)
 
 ## How to add a case study
 
+* Create a new branch to work on a case study.
 * Edit the qmd or md files in the `content` folder. qmd files can include code (R) and lots of Quarto markdown bells and whistles (like call-outs, cross-references, auto-citations and much more).
-* Add the files to `_quarto.yml`
+* Add the files to `_quarto.yml`.
+* Submit a pull request when finished working on a case study. If the case study renders successfully, the rendered pages will be uploaded to the artifacts section of the GitHub Actions page. If the case study fails to render, developers can review the GitHub Actions log to debug.
 
 <hr>
 


### PR DESCRIPTION
This PR resolves issue #13. The following modifications have been implemented:

- Implemented a GitHub Actions (GHA) workflow to render the Quarto project upon pull request. If the case study renders successfully, the rendered pages will be uploaded to the artifacts section of the GitHub Actions page for review. If the case study fails to render, developers can review the GitHub Actions log to debug.
- Included detailed instructions on adding a new case study.

