### PR TITLE
Allows manually starting render-on-pull-request.yml

### DIFF
--- a/.github/workflows/render-on-pull-request.yml
+++ b/.github/workflows/render-on-pull-request.yml
@@ -1,6 +1,7 @@
 on:
   pull_request:
     branches: main
+  workflow_dispatch:
 
 name: Render on pull request
 


### PR DESCRIPTION
I was frustrated when I pushed that I had to open a PR to see if the changes worked, this way I can manually run the workflow on any branch without causing a ton of runs every time someone pushes to a feature branch.