### PR TITLE
fix: resolve rendering issue for sardine qmd file

### DIFF
--- a/content/SWFSC-sardine.qmd
+++ b/content/SWFSC-sardine.qmd
@@ -324,7 +324,7 @@ recruitment$estimate_log_devs <- estimate_recdevs
 recruitment$log_devs <- rep(log(1), nyears) # set to no deviations (multiplier) to start
 
 # growth
-wtatage <- SS_readwtatage("data_files/sardine_wtatage.ss_new")
+wtatage <- r4ss::SS_readwtatage("data_files/sardine_wtatage.ss_new")
 
 ewaa_growth <- methods::new(EWAAgrowth)
 ewaa_growth$ages <- ages

--- a/content/pc.qmd
+++ b/content/pc.qmd
@@ -91,7 +91,7 @@ estimate_q3 <- TRUE
 estimate_q6 <- TRUE
 estimate_F <- TRUE
 estimate_recdevs <- TRUE
-source("pk_prepare_FIMS_inputs.R")
+source("R/pk_prepare_FIMS_inputs.R")
 ## make FIMS model
 success <- CreateTMBModel()
 parameters <- list(p = get_fixed())

--- a/content/setup.qmd
+++ b/content/setup.qmd
@@ -3,8 +3,7 @@
 #| label: package-installation
 
 # Names of required packages
-packages <- c("dplyr", "tidyr", "ggplot2", "TMB", "reshape2", "here", "remotes", "lubridate",
-              "r4ss")
+packages <- c("dplyr", "tidyr", "ggplot2", "TMB", "reshape2", "here", "remotes", "lubridate")
 
 # Install packages not yet installed
 installed_packages <- packages %in% rownames(installed.packages())


### PR DESCRIPTION
This PR resolves the rendering issue for the SWFSC sardine case study. The change include

- Replacing the installation of {r4ss} from CRAN with installation from GitHub in the `setup.qmd` file.
- Updating the path to the source file `pk_prepare_FIMS_inputs.R`.
- Using `r4ss::` to access the `SS_readwtatage()` function in the `SWFSC-sardine.qmd` file.