### PR TITLE
fix($report()): Use obj$env$last.par.best

### DIFF
--- a/content/AFSC-GOA-pollock.qmd
+++ b/content/AFSC-GOA-pollock.qmd
@@ -102,7 +102,7 @@ rep1 <- obj$report() # FIMS initial values
 opt <- TMBhelper::fit_tmb(obj, getsd=FALSE, newtonsteps=0, control=list(trace=100))
 ## opt <- with(obj, nlminb(start=par, objective=fn, gradient=gr))
 max(abs(obj$gr())) # from Cole, can use TMBhelper::fit_tmb to get val to <1e-10
-rep2 <- obj$report() ## FIMS after estimation
+rep2 <- obj$report(obj$env$last.par.best) ## FIMS after estimation
 
 ## Output plotting
 out1 <- get_long_outputs(rep1, rep0) %>%
@@ -199,7 +199,7 @@ for(j in 1:length(xseq)){
   parameters$p[i] <- xseq[j]
   obj2 <- MakeADFun(data = list(), parameters, DLL = "FIMS", silent = TRUE, map=map)
   opt2 <- TMBhelper::fit_tmb(obj2, getsd=FALSE, newtonsteps=0, control=list(trace=0))
-  out <- obj2$report()
+  out <- obj2$report(obj2$env$last.par.best)
   res[[j]] <- data.frame(j=j, lnR0=xseq[j], total=out$jnll, index=out$index_nll,
                          age=out$age_comp_nll,recruit=out$rec_nll, maxgrad=max(abs(obj$gr())))
 }

--- a/content/NEFSC-yellowtail.qmd
+++ b/content/NEFSC-yellowtail.qmd
@@ -302,7 +302,7 @@ opt <- nlminb(start=obj$par, objective=obj$fn, gradient=obj$gr,
 
 sdr <- TMB::sdreport(obj)
 sdr_fixed <- summary(sdr, "fixed")
-report <- obj$report()
+report <- obj$report(obj$env$last.par.best)
 
 ### Plotting
 

--- a/content/NWFSC-petrale.qmd
+++ b/content/NWFSC-petrale.qmd
@@ -308,7 +308,7 @@ print(opt)
 #| label: get-results
 #| output: false
 #| eval: true
-report <- obj$report()
+report <- obj$report(obj$env$last.par.best)
 # copy input data to use as basis for results
 results_frame <- age_frame@data
 results_frame$expected <- NA

--- a/content/PIFS-opakapaka.qmd
+++ b/content/PIFS-opakapaka.qmd
@@ -244,7 +244,7 @@ parameters <- list(p = get_fixed())
 obj <- MakeADFun(data = list(), parameters, DLL = "FIMS", silent = TRUE)
 opt <- nlminb(obj$par, obj$fn, obj$gr, control = list(eval.max = 10000, iter.max = 10000))
 #print(opt)
-report <- obj$report()
+report <- obj$report(obj$env$last.par.best)
 ```
 
 ## Results from FIMS model

--- a/content/SEFSC-scamp.qmd
+++ b/content/SEFSC-scamp.qmd
@@ -400,7 +400,7 @@ opt <- nlminb(obj$par, obj$fn, obj$gr,
 # TMB reporting
 sdr <- TMB::sdreport(obj)
 sdr_fixed <- summary(sdr, "fixed")
-report <- obj$report()
+report <- obj$report(obj$env$last.par.best)
 
 # print(sdr_fixed)
 

--- a/content/SWFSC-sardine.qmd
+++ b/content/SWFSC-sardine.qmd
@@ -433,7 +433,7 @@ pars <- tibble(parname = parname, startingvals = parameters$p)
 
 
 obj <- MakeADFun(data = list(), parameters, DLL = "FIMS", silent = TRUE)
-report <- obj$report()
+report <- obj$report(obj$env$last.par.best)
 
 #Are there flags for when something is going wrong with the model where initial values
 #are all 0?


### PR DESCRIPTION
# What is the feature?
* See NOAA-FIMS/FIMS#616 for why but in short there is a need to use a single iteration of the optimization routine so you know you will get the same results.

# How have you implemented the solution?
* `obj$report(obj$env$last.par.best)`, except for the first instance of this in the GOA case study where @Cole-Monnahan-NOAA is just getting the initial values. I am not sure if this one needs to be changed as well.

# Does the PR impact any other area of the project, maybe another repo?
* NA

@Cole-Monnahan-NOAA can you please quickly review this. Mainly, I want to
1. ensure I am implementing the solution appropriately
2. that I fixed all necessary instances (I just used a grep to find them all)
3. that the first instance of obj$report() in the GOA case study does not need to change
https://github.com/NOAA-FIMS/case-studies/blob/d672a75415034fcb48c0f653bcc1ceadde5785ee/content/AFSC-GOA-pollock.qmd#L100

Thanks.
