### PR TITLE
refactor(proportion_female): Remove comments

### DIFF
--- a/content/NWFSC-petrale.qmd
+++ b/content/NWFSC-petrale.qmd
@@ -275,7 +275,6 @@ population$ages <- ages
 population$nfleets <- 2 # fleets plus surveys
 population$nseasons <- nseasons
 population$nyears <- nyears
-# population$proportion_female <- rep(0.5, nages)
 
 population$SetMaturity(maturity$get_id())
 population$SetGrowth(ewaa_growth$get_id())

--- a/content/PFISC-opakapaka.r
+++ b/content/PFISC-opakapaka.r
@@ -237,7 +237,6 @@ population$ages <- ages
 population$nfleets <- 2 # fleet plus surveys
 population$nseasons <- 1
 population$nyears <- nyears
-# population$proportion_female <- rep(0.5, nages)
 
 population$SetMaturity(maturity$get_id())
 population$SetGrowth(ewaa_growth$get_id())

--- a/content/SEFSC-scamp.qmd
+++ b/content/SEFSC-scamp.qmd
@@ -370,7 +370,6 @@ population$log_M <-
 population$estimate_M <- FALSE
 population$log_init_naa <- log(sca$N.age[1, ])
 population$estimate_init_naa <- FALSE
-# population$proportion_female <- rep(1.0,nages) #For scamp, assuming all females (see maturity note above)
 population$nages <- nages
 population$ages <- ages
 population$nfleets <- 3 # 2 fleets and 1 survey
@@ -713,8 +712,8 @@ if ```FIMS::m_landings``` took fleet as an argument, similar to ```FIMS::m_ageco
 
 ## List any issues that you ran into or found
 
-The FIMS feature to assign proportion female at age is not yet functional. FIMS accepts proportion female at age
-as input, but does not use that input and instead hard-codes a 50:50 sex ratio. Many stocks
+The FIMS feature to assign proportion female at age is not yet functional and
+it is hard-coded using a 50:50 sex ratio. Many stocks
 in the southeast are protogynous hermphrodites, such that individuals start life as females and later convert to males.
 This life history creates a sex ratio that is tilted toward females for younger ages and males for older ages.
 

--- a/content/SWFSC-sardine.qmd
+++ b/content/SWFSC-sardine.qmd
@@ -378,7 +378,6 @@ population$ages <- ages
 population$nfleets <- 2 # fleets plus surveys
 population$nseasons <- nseasons
 population$nyears <- nyears
-# population$proportion_female <- rep(0.5, nages)
 
 population$SetMaturity(maturity$get_id())
 population$SetGrowth(ewaa_growth$get_id())

--- a/content/sardine_fims.R
+++ b/content/sardine_fims.R
@@ -566,7 +566,6 @@ population$ages <- ages
 population$nfleets <- 2 # fleets plus surveys
 population$nseasons <- nseasons
 population$nyears <- nyears
-# population$proportion_female <- rep(0.5, nages)
 
 population$SetMaturity(maturity$get_id())
 population$SetGrowth(ewaa_growth$get_id())
@@ -813,7 +812,6 @@ population$ages <- ages
 population$nfleets <- 2 # fleets plus surveys
 population$nseasons <- nseasons
 population$nyears <- nyears
-# population$proportion_female <- rep(0.5, nages)
 
 population$SetMaturity(maturity$get_id())
 population$SetGrowth(ewaa_growth$get_id())


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* proportion_female was commented out in all of the case studies because setting it was not doing anything to the model.
* In M2 we will remove the ability to set this parameter vector because it was not doing anything.
* In the future we will add the feature back.

# How have you implemented the solution?
* Removed all of the lines that were commented out for setting proportion_female
* Simplified a comment in the scamp case study to say that it is fixed at 0.5 instead of you have the ability to estimate it.

# Does the PR impact any other area of the project, maybe another repo?
*  This change does nothing to the results.
* Part of NOAA-FIMS/FIMS#638
* NOAA-FIMS/seaside-chats#7