### PR TITLE
Fix render issues caused by r4ss changes

### DIFF
--- a/content/NWFSC-petrale.qmd
+++ b/content/NWFSC-petrale.qmd
@@ -77,8 +77,8 @@ source("R/get_ss3_data.R")
 # by assigning to fleet -1, these get filtered by get_ss3_data()
 
 # only include age comps with fleet = -4 or 1:
-ss3dat$agecomp <- ss3dat$agecomp |> dplyr::filter(FltSvy %in% c(-4, 1))
-ss3dat$agecomp$FltSvy <- abs(ss3dat$agecomp$FltSvy)
+ss3dat$agecomp <- ss3dat$agecomp |> dplyr::filter(fleet %in% c(-4, 1))
+ss3dat$agecomp$fleet <- abs(ss3dat$agecomp$fleet)
 
 # convert SS3 data into FIMS format using function defined in the R directory
 mydat <- get_ss3_data(ss3dat, fleets = c(1,4), ages = ages)

--- a/content/PIFS-opakapaka.qmd
+++ b/content/PIFS-opakapaka.qmd
@@ -53,8 +53,13 @@ load(file.path(getwd(), "data_files", "opaka_model.RDS"))
 ## Should now have ss3dat, ss3ctl, and ss3rep in environment
 ## RDS file can also be found at
 #githubURL <- "https://github.com/MOshima-PIFSC/Opaka-FIMS-Case-Study/blob/main/Model/FIMS-em/1/em/opaka_model.RDS"
+# replace ss3dat and ss3ctl loaded from RDS file with new versions 
+# using current r4ss to read ss_new files from github
+opaka_input <- r4ss::SS_read("https://raw.githubusercontent.com/MOshima-PIFSC/Opaka-FIMS-Case-Study/refs/heads/main/Model/FIMS-em/1/em/", ss_new = TRUE)
+ss3dat <- opaka_input$dat
+ss3ctl <- opaka_input$ctl
 
-## Function written by Ian Taylor to get SS3 data into FIMSFrame format
+## Function written by Ian Taylor and Meg Oshima to get SS3 data into FIMSFrame format
 source("./R/get_ss3_data.R")
 
 # Define the dimensions ----

--- a/content/SWFSC-sardine.qmd
+++ b/content/SWFSC-sardine.qmd
@@ -330,7 +330,7 @@ ewaa_growth <- methods::new(EWAAgrowth)
 ewaa_growth$ages <- ages
 # NOTE: getting weight-at-age vector from
 # petrale_output$wtatage |>
-#   dplyr::filter(Sex == 1 & Fleet == -1 & Yr == 1876) |>
+#   dplyr::filter(sex == 1 & fleet == -1 & year == 1876) |>
 #   dplyr::select(paste(0:40)) |>
 #   round(4)
 # ewaa_growth$weights <- c(0.019490,0.077760,0.108865,
@@ -338,7 +338,7 @@ ewaa_growth$ages <- ages
 #                          0.196460,0.214155)
 
 
-ewaa_growth$weights <- wtatage %>% filter(Fleet == 1, Yr == 2010) %>% select(as.character(0:10))  %>% t %>%
+ewaa_growth$weights <- wtatage %>% filter(fleet == 1, year == 2010) %>% select(as.character(0:10))  %>% t %>%
   as.vector
 
 # maturity


### PR DESCRIPTION
## What is the feature?
* Render was failing in the recent PR https://github.com/NOAA-FIMS/case-studies/pull/47 due to changes in the dependent package r4ss.

## How have you implemented the solution?
* Changes to petrale, opakapaka and sardine were needed to match new column names used in r4ss discussed in https://github.com/r4ss/r4ss/issues/512.
* A change to the r4ss package was also required to read the ss_new files from github: https://github.com/r4ss/r4ss/commit/36a04d7007562f3114db39bdcca06725e8589f56, so rendering correctly depends on the current version of r4ss on github.

## Does the PR impact any other area of the project, maybe another repo?
* No

## Additional info
The opakapaka model was reading an RDS file that contained the information on both SS3 inputs (data and control), and SS3 output. The inputs did not work with the modified r4ss, so I've added a read of these files directly from github to replace the ones in the RDS file. In the future, the RDS file could be updated using the current r4ss.
