### PR TITLE
Removes TMBhelper from case-studies

### DIFF
--- a/content/AFSC-GOA-pollock.qmd
+++ b/content/AFSC-GOA-pollock.qmd
@@ -209,7 +209,17 @@ for(j in 1:length(xseq)){
   print(j)
   parameters$p[i] <- xseq[j]
   obj2 <- MakeADFun(data = list(), parameters, DLL = "FIMS", silent = TRUE, map=map)
-  opt2 <- TMBhelper::fit_tmb(obj2, getsd=FALSE, newtonsteps=0, control=list(trace=0))
+  opt2 <- with(
+    obj,
+    stats::nlminb(
+      start = par,
+      objective = fn,
+      gradient = gr,
+      control = list(
+        trace = 0
+      )
+    )
+  )
   out <- obj2$report(obj2$env$last.par.best)
   nll_components <- out$nll_components
   index_nll <- sum(nll_components[seq(2, length(nll_components), by = 2)])

--- a/content/SWFSC-sardine.qmd
+++ b/content/SWFSC-sardine.qmd
@@ -61,8 +61,6 @@ How I simplified my assessment
 # withr::local_options(pkg.build_extra_flags = FALSE)
 #
 # library(TMB)
-# # devtools::install_github("kaskr/TMB_contrib_R/TMBhelper")
-# library(TMBhelper)
 # library(r4ss)
 #
 # #Local version of FIMS downloaded last week

--- a/content/setup.qmd
+++ b/content/setup.qmd
@@ -11,7 +11,6 @@ if (any(installed_packages == FALSE)) {
   install.packages(packages[!installed_packages], repos = "http://cran.us.r-project.org")
 }
 
-remotes::install_github("kaskr/TMB_contrib_R/TMBhelper")
 remotes::install_github("NOAA-FIMS/FIMS")
 remotes::install_github("r4ss/r4ss")
 
@@ -19,7 +18,6 @@ remotes::install_github("r4ss/r4ss")
 invisible(lapply(packages, library, character.only = TRUE))
 
 library(FIMS)
-library(TMBhelper)
 
 R_version <- version$version.string
 TMB_version <- packageDescription("TMB")$Version


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Removes the R package TMBhelper, which was already done in this branch by @Cole-Monnahan-NOAA but this PR is a rebase to main and removal of some code that was commented out.

# How have you implemented the solution?
* Removed the github_install() call and the library call from setup.qmd
* Removed the commented out library() call in sardine
* Changed the one remaining call to TMBhelper() in the pollock case study to use `with(obj, stats::nlminb())`, @Cole-Monnahan-NOAA can you please verify that I did this correctly on line 212.

# Does the PR impact any other area of the project, maybe another repo?
* No
