### PR TITLE
fix sidebar link to acknowledgements

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,6 +5,7 @@ project:
     - content/AFSC-GOA-pollock.qmd
     - content/NEFSC-yellowtail.qmd
     - content/pacific-hake.qmd
+    - content/acknowledgements.qmd
 
 website:
   page-navigation: true


### PR DESCRIPTION
# What is the feature?
* The acknowledgements.qmd file wasn't listed in the render section of _quarto.yml causing this issue helpfully flagged by @sbreitbart-NOAA 
* fixes https://github.com/NOAA-FIMS/FIMS/issues/1515 (hopefully, I haven't rendered the site locally to confirm)

# How have you implemented the solution?
* Expand the render section

# Does the PR impact any other area of the project, maybe another repo?
* No
